### PR TITLE
Tune log level for LDAP attribute store

### DIFF
--- a/src/satosa/micro_services/ldap_attribute_store.py
+++ b/src/satosa/micro_services/ldap_attribute_store.py
@@ -327,5 +327,5 @@ class LdapAttributeStore(satosa.micro_services.base.ResponseMicroService):
                 satosa_logging(logger, logging.INFO, "{} Redirecting to {}".format(logprefix, url), context.state)
                 return Redirect(url)
 
-        satosa_logging(logger, logging.DEBUG, "{} returning data.attributes {}".format(logprefix, str(data.attributes)), context.state)
+        satosa_logging(logger, logging.INFO, "{} returning data.attributes {}".format(logprefix, str(data.attributes)), context.state)
         return super().process(context, data)


### PR DESCRIPTION
Set the last logging call in the process() method for the
LDAP attribute store to log at level INFO instead of DEBUG so
that at INFO the list of returned attributes is logged.